### PR TITLE
Skip cleanup before Travis CI deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ script: bundle exec middleman build
 deploy:
   provider: script
   script: scripts/deploy.sh
+  skip_cleanup: true
   on:
     repo: big-burrito/big-burrito
     branch: master

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,6 +2,6 @@
 
 set -x
 
-rvm use $TRAVIS_RUBY_VERSION
+rvm use $(< .ruby-version) --fuzzy
 gem install s3_website
 s3_website push


### PR DESCRIPTION
Since we build the site in the "test" phase, and don't want to re-build it when deploying, we tell the deploy phase to skip the normal cleanup that it does.