### PR TITLE
Turn on directory indexes all the time

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -37,12 +37,13 @@ page '/*.txt', layout: false
 #   end
 # end
 
+activate :directory_indexes
+
 # Build-specific configuration
 # https://middlemanapp.com/advanced/configuration/#environment-specific-settings
 
 configure :build do
   activate :minify_css
   activate :minify_javascript
-  activate :directory_indexes
   activate :asset_hash
 end


### PR DESCRIPTION
We really want directory indexes on all the time, not just during build. This lets us more easily test & develop.