### PR TITLE
Add basic /events.ics support

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -1,0 +1,20 @@
+# This should be an array of events, and is used to populate both the
+# /events.ics file, and the listing on the site. The end, and
+# description are optional properties, title, and start are
+# required. Start and end are any value that Ruby's DateTime.parse can
+# handle, and should really include timezone information.
+#
+# - title: Example event
+#   start: 2017-06-20T18:00:00-07:00
+#   end: 2017-06-20T19:00:00-07:00
+#   description: |
+#     Multiline
+#     description
+#     goes
+#     here
+
+---
+- title: Stormblood release
+  start: 2017-06-20T18:00:00-07:00
+- title: Stormblood early access
+  start: 2017-06-16T18:00:00-07:00

--- a/helpers/icalendar_helpers.rb
+++ b/helpers/icalendar_helpers.rb
@@ -1,0 +1,13 @@
+module IcalendarHelpers
+  def ical_datetime_to_stamp(input_datetime)
+    input_datetime.getutc.strftime("%Y%m%dT%H%M%SZ")
+  end
+
+  def ical_format_description(event_description)
+    event_description.gsub(/\n/, '\n')
+  end
+
+  def ical_generate_uid(event)
+    "#{ical_datetime_to_stamp(event.start)}@big-burrito.com"
+  end
+end

--- a/source/events.ics.erb
+++ b/source/events.ics.erb
@@ -1,0 +1,19 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:Big Burrito Free Company//big-burrito.com//EN
+<% data.events.each do |event| -%>
+BEGIN:VEVENT
+UID:<%= ical_generate_uid event %>
+SUMMARY:<%= event.title %>
+<% if event.description -%>
+DESCRIPTION:<%= ical_format_description event.description %>
+<% end -%>
+CLASS:PUBLIC
+DTSTART:<%= ical_datetime_to_stamp event.start %>
+<% if event.end -%>
+DTEND:<%= ical_datetime_to_stamp event.end %>
+<% end -%>
+DTSTAMP:<%= ical_datetime_to_stamp Time.now %>
+END:VEVENT
+<% end -%>
+END:VCALENDAR


### PR DESCRIPTION
This adds a very basic /events.ics that is built from the data/events.yaml file. There are also a few helpers for generating a (not actually stable) UID for each event, and for formatting the DateTime objects appropriately for the iCalendar specification.

Helpful links:
  * http://www.kanzaki.com/docs/ical/
  * http://www.ietf.org/rfc/rfc2445.txt